### PR TITLE
Add digested CMS verification

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -230,6 +230,35 @@ paths:
         '200':
           $ref: '#/components/responses/CmsVerificationResponse'
 
+  /cms/verify/digested:
+    post:
+      tags:
+        - CMS
+      summary: Проверяет CMS, подписанный только хэшем.
+      requestBody:
+        description: Запрос на проверку подписи по хэшу
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/VerifyRequest'
+                - properties:
+                    cms:
+                      $ref: '#/components/schemas/Cms'
+                    hash:
+                      type: string
+                      description: Хэш данных в формате Base64
+                    digestedOnly:
+                      type: boolean
+                      default: true
+                      description: Не хэшировать повторно переданный хэш
+                - required:
+                    - cms
+                    - hash
+      responses:
+        '200':
+          $ref: '#/components/responses/CmsVerificationResponse'
+
   /cms/extract:
     post:
       tags:

--- a/src/main/java/kz/ncanode/controller/CmsController.java
+++ b/src/main/java/kz/ncanode/controller/CmsController.java
@@ -3,6 +3,7 @@ package kz.ncanode.controller;
 import kz.ncanode.dto.certificate.CertificateRevocation;
 import kz.ncanode.dto.request.CmsCreateRequest;
 import kz.ncanode.dto.request.CmsVerifyRequest;
+import kz.ncanode.dto.request.CmsVerifyDigestedRequest;
 import kz.ncanode.dto.response.CmsDataResponse;
 import kz.ncanode.dto.response.CmsResponse;
 import kz.ncanode.dto.response.CmsVerificationResponse;
@@ -38,6 +39,16 @@ public class CmsController {
             cmsVerifyRequest.getData(),
             cmsVerifyRequest.getRevocationCheck().contains(CertificateRevocation.OCSP),
             cmsVerifyRequest.getRevocationCheck().contains(CertificateRevocation.CRL)
+        ));
+    }
+
+    @PostMapping("/verify/digested")
+    public ResponseEntity<CmsVerificationResponse> verifyDigested(@Valid @RequestBody CmsVerifyDigestedRequest request) {
+        return ResponseEntity.ok(cmsService.verifyDigested(
+            request.getCms(),
+            request.getHash(),
+            request.getRevocationCheck().contains(CertificateRevocation.OCSP),
+            request.getRevocationCheck().contains(CertificateRevocation.CRL)
         ));
     }
 

--- a/src/main/java/kz/ncanode/dto/request/CmsVerifyDigestedRequest.java
+++ b/src/main/java/kz/ncanode/dto/request/CmsVerifyDigestedRequest.java
@@ -1,0 +1,22 @@
+package kz.ncanode.dto.request;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+
+import javax.validation.constraints.NotEmpty;
+
+@Jacksonized
+@EqualsAndHashCode(callSuper = true)
+@Data
+@SuperBuilder
+public class CmsVerifyDigestedRequest extends VerifyRequest {
+    @NotEmpty
+    private String cms;
+
+    @NotEmpty
+    private String hash;
+
+    private boolean digestedOnly = true;
+}

--- a/src/test/groovy/kz/ncanode/integration/CmsIntegrationTest.groovy
+++ b/src/test/groovy/kz/ncanode/integration/CmsIntegrationTest.groovy
@@ -5,6 +5,7 @@ import kz.ncanode.common.IntegrationSpecification
 import kz.ncanode.controller.CmsController
 import kz.ncanode.dto.request.CmsCreateRequest
 import kz.ncanode.dto.request.CmsVerifyRequest
+import kz.ncanode.dto.request.CmsVerifyDigestedRequest
 import kz.ncanode.dto.request.SignerRequest
 import kz.ncanode.dto.response.CmsDataResponse
 import kz.ncanode.dto.response.CmsResponse
@@ -24,6 +25,7 @@ class CmsIntegrationTest extends IntegrationSpecification {
     private final static String URI_SIGN = "/cms/sign"
     private final static String URI_SIGN_ADD = "/cms/sign/add"
     private final static String URI_VERIFY = "/cms/verify"
+    private final static String URI_VERIFY_DIGESTED = "/cms/verify/digested"
     private final static String URI_EXTRACT = "/cms/extract"
 
     @Autowired
@@ -85,6 +87,24 @@ class CmsIntegrationTest extends IntegrationSpecification {
 
         when:
         def response = doPostQuery(URI_VERIFY, requestJson, 200, CmsVerificationResponse)
+
+        then:
+        response != null
+        response.signers.size() == 1
+        !response.valid
+    }
+
+    def "test verify digested"() {
+        given:
+        def request = CmsVerifyDigestedRequest.builder()
+            .cms(SIGNED_CMS)
+            .hash(Base64.encoder.encodeToString(TEST_DATA.getBytes(StandardCharsets.UTF_8)))
+            .build()
+
+        def requestJson = new ObjectMapper().writeValueAsString(request)
+
+        when:
+        def response = doPostQuery(URI_VERIFY_DIGESTED, requestJson, 200, CmsVerificationResponse)
 
         then:
         response != null


### PR DESCRIPTION
## Summary
- add `/cms/verify/digested` endpoint
- skip extra hashing when verifying pre-digested CMS
- provide request object `CmsVerifyDigestedRequest`
- test digested verification